### PR TITLE
fix(types): roll up declaration entrypoint

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
 	plugins: [
 		dts({
 			insertTypesEntry: true,
+			rollupTypes: true,
 		}),
 	],
 	build: {


### PR DESCRIPTION
## Contexto

Consumidores usando TypeScript com `moduleResolution: "NodeNext"` podem falhar ao encontrar ou resolver corretamente as tipagens publicadas quando o pacote expõe apenas o entrypoint principal em `exports["."]`, mas a geração de declarações deixa a API pública distribuída em arquivos internos.

Este pacote publica somente o entrypoint `.` e aponta `exports["."].types` para `./dist/index.d.ts`. Por isso, faz sentido que o arquivo de tipos publicado represente a API pública completa desse entrypoint.

## Caso de teste
https://stackblitz.com/edit/vitejs-vite-tjcmhkry?file=tsconfig.json

Pode ser validado que o `moduleResolution` com o valor `bundle` resulta no correto funcionamento do intellisense e da identificação dos tipos pelo TS. Porém ao trocar o valor para `NodeNext`, perde-se a tipagem do pacote.

| NodeNext  | Bundle  |
|---|---|
| <img width="425" height="97" alt="image" src="https://github.com/user-attachments/assets/07db5df9-d943-4ad1-9814-bd9a4d349d55" />  | <img width="622" height="262" alt="image" src="https://github.com/user-attachments/assets/aa42cfac-3c9c-4c51-adc9-7411102b61f6" />  |

## Alteração

Ativa `rollupTypes: true` no `vite-plugin-dts`, mantendo `insertTypesEntry: true`.

Com isso, a geração de declarações passa a consolidar os tipos em `dist/index.d.ts`, reduzindo a dependência de referências internas na resolução de tipos do consumidor.

## Justificativa

- Corrige o consumo em projetos TypeScript configurados com `moduleResolution: "NodeNext"`.
- Mantém as tipagens alinhadas com o formato de publicação atual, que expõe apenas o entrypoint principal.
- Evita que o consumidor precise depender da estrutura interna de arquivos de declaração emitidos em `dist`.

## Pontos negativos

- O build de tipos fica mais lento, porque `rollupTypes` usa `@microsoft/api-extractor` internamente.
- A etapa de build passa a ser mais sensível a problemas de declaração, aliases, `baseUrl`, imports não padrão ou limitações do resolver do API Extractor.
- O `dist/index.d.ts` gerado pode ficar maior e menos legível, porque ele precisa carregar a superfície pública em um único arquivo.
- Se no futuro o pacote passar a suportar subpath exports, como `@brazilian-utils/brazilian-utils/format-cpf`, a estratégia de tipos precisará ser reavaliada para esses entrypoints.

## Validação

- `pnpm install`
- `pnpm build`
- `pnpm check`
- Teste mínimo de consumo com `moduleResolution: "NodeNext"` importando `isValidCnpj` e `parseCnpj`