### PR TITLE
[2.4.0 stack 7/18] Public API: root exports, types, 100% coverage and type-aware lint gates

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,26 +1,129 @@
 import { describe, expect, test } from "./_internals/test/runtime";
+import type {
+	AddBusinessDaysParams,
+	AddressInfo,
+	AreaCodeInfo,
+	Bank,
+	BoletoInfo,
+	CapitalizeOptions,
+	Cbo,
+	CepAddressInfo,
+	CepProvider,
+	Certidao,
+	CertidaoType,
+	Cfop,
+	Cnae,
+	ConvertCurrencyToWordsOptions,
+	ConvertDateToWordsOptions,
+	ConvertNumberToWordsOptions,
+	DifferenceInBusinessDaysParams,
+	FormatBoletoOptions,
+	FormatCaepfOptions,
+	FormatCeiOptions,
+	FormatCepOptions,
+	FormatCertidaoOptions,
+	FormatCnhOptions,
+	FormatCnoOptions,
+	FormatCnpjOptions,
+	FormatCnsOptions,
+	FormatCpfOptions,
+	FormatCurrencyOptions,
+	FormatPhoneOptions,
+	FormatPisOptions,
+	FormatProcessoJuridicoOptions,
+	GenerateBoletoOptions,
+	GenerateLicensePlateFormat,
+	GeneratePhoneType,
+	GeneratePixPayloadParams,
+	GenerateProcessoJuridicoOptions,
+	GetAddressInfoByCepOptions,
+	GetBoletoInfoOptions,
+	GetCepInfoByAddressOptions,
+	GetHolidaysOptions,
+	GetMunicipalityByCodeOptions,
+	GetMunicipalityByNameOptions,
+	GetMunicipalityOptions,
+	Holiday,
+	HolidayType,
+	Iban,
+	IsBusinessDayOptions,
+	IsHolidayOptions,
+	IsValidBankAccountOptions,
+	IsValidBankAccountParams,
+	IsValidCertidaoOptions,
+	IsValidCnpjOptions,
+	IsValidCstOptions,
+	IsValidMobilePhoneOptions,
+	IsValidPhoneOptions,
+	IsValidPixKeyOptions,
+	IsValidRegistroProfissionalOptions,
+	LegalNature,
+	LicensePlateFormat,
+	Municipality,
+	NfeKey,
+	NumberToWordsGender,
+	ParseCnpjOptions,
+	ParseCurrencyOptions,
+	PhoneMask,
+	PhoneType,
+	PhoneVersion,
+	PixKey,
+	PixKeyType,
+	PixPayload,
+	PixPointOfInitiation,
+	RegistroProfissionalCouncil,
+	State,
+	StateCode,
+	StateName,
+	WordsCase,
+} from "./index";
 import * as brazilianUtils from "./index";
 
 const PUBLIC = [
+	"GetAddressInfoByCepError",
+	"GetAddressInfoByCepNotFoundError",
+	"GetAddressInfoByCepServiceError",
+	"GetAddressInfoByCepValidationError",
+	"GetCepInfoByAddressError",
+	"GetCepInfoByAddressNotFoundError",
+	"GetCepInfoByAddressValidationError",
+	"addBusinessDays",
 	"capitalize",
-	"formatCep",
+	"convertCurrencyToWords",
+	"convertDateToWords",
+	"convertLicensePlateToMercosul",
+	"convertNumberToWords",
+	"differenceInBusinessDays",
 	"formatBoleto",
+	"formatCEP",
+	"formatCNPJ",
+	"formatCPF",
+	"formatCaepf",
+	"formatCei",
+	"formatCep",
+	"formatCertidao",
+	"formatCnae",
 	"formatCnh",
+	"formatCno",
 	"formatCnpj",
+	"formatCns",
 	"formatCpf",
 	"formatCurrency",
+	"formatIban",
 	"formatLegalNature",
 	"formatLicensePlate",
+	"formatNcm",
+	"formatNfeKey",
 	"formatPassport",
 	"formatPhone",
 	"formatPis",
 	"formatProcessoJuridico",
 	"formatVoterId",
 	"generateBoleto",
-	"generateCep",
-	"generateCnh",
 	"generateCNPJ",
 	"generateCPF",
+	"generateCep",
+	"generateCnh",
 	"generateCnpj",
 	"generateCpf",
 	"generateLegalNature",
@@ -28,71 +131,242 @@ const PUBLIC = [
 	"generatePassport",
 	"generatePhone",
 	"generatePis",
+	"generatePixPayload",
 	"generateProcessoJuridico",
 	"generateVoterId",
 	"getAddressInfoByCep",
-	"GetAddressInfoByCepError",
-	"GetAddressInfoByCepNotFoundError",
-	"GetAddressInfoByCepServiceError",
-	"GetAddressInfoByCepValidationError",
+	"getAreaCodeInfo",
+	"getAreaCodesByState",
+	"getBankByCode",
+	"getBankByIspb",
+	"getBanks",
 	"getBoletoInfo",
+	"getCbo",
 	"getCepInfoByAddress",
-	"GetCepInfoByAddressError",
-	"GetCepInfoByAddressNotFoundError",
-	"GetCepInfoByAddressValidationError",
+	"getCfop",
 	"getCities",
+	"getCnae",
 	"getFormatLicensePlate",
 	"getHolidays",
+	"getLegalNature",
 	"getLegalNatures",
+	"getMunicipalities",
 	"getMunicipality",
+	"getMunicipalityByCode",
+	"getStateByIbgeCode",
+	"getStateCodeByName",
+	"getStateNameByCode",
 	"getStates",
+	"getTimezoneByState",
+	"isBusinessDay",
 	"isHoliday",
 	"isValidBankAccount",
 	"isValidBoleto",
 	"isValidCEP",
 	"isValidCNPJ",
 	"isValidCPF",
+	"isValidCaepf",
+	"isValidCbo",
+	"isValidCei",
 	"isValidCep",
+	"isValidCertidao",
+	"isValidCfop",
+	"isValidCnae",
 	"isValidCnh",
+	"isValidCno",
 	"isValidCnpj",
+	"isValidCns",
 	"isValidCpf",
+	"isValidCreditCard",
+	"isValidCsosn",
+	"isValidCst",
 	"isValidEmail",
 	"isValidIE",
+	"isValidIban",
 	"isValidIe",
 	"isValidLandlinePhone",
 	"isValidLegalNature",
 	"isValidLicensePlate",
 	"isValidMobilePhone",
+	"isValidNcm",
+	"isValidNfeKey",
 	"isValidPIS",
 	"isValidPassport",
 	"isValidPhone",
 	"isValidPis",
+	"isValidPixKey",
+	"isValidPixPayload",
 	"isValidProcessoJuridico",
+	"isValidRegistroProfissional",
 	"isValidRenavam",
+	"isValidServicePhone",
+	"isValidVin",
 	"isValidVoterId",
 	"parseBoleto",
 	"parseCep",
+	"parseCertidao",
 	"parseCnh",
 	"parseCnpj",
 	"parseCpf",
-	"formatCurrency",
 	"parseCurrency",
+	"parseIban",
 	"parseLegalNature",
 	"parseLicensePlate",
+	"parseNfeKey",
 	"parsePassport",
 	"parsePhone",
 	"parsePis",
+	"parsePixKey",
+	"parsePixPayload",
 	"parseProcessoJuridico",
 	"parseVoterId",
-	"formatCEP",
-	"formatCNPJ",
-	"formatCPF",
+	"removeAccents",
+].sort();
+
+const NETWORK_ENTRY_POINTS = new Set(["getAddressInfoByCep", "getCepInfoByAddress"]);
+
+const BAD_INPUTS: Array<[string, unknown]> = [
+	["null", null],
+	["undefined", undefined],
+	["a number", 123],
+	["an empty string", ""],
+	["a blank string", "   "],
+	["an object", {}],
+	["an array", []],
+	["NaN", Number.NaN],
+	["a boolean", true],
 ];
 
+const isErrorClass = (name: string): boolean => /^[A-Z]/.test(name);
+
 describe("Public API", () => {
-	for (const util of Object.keys(brazilianUtils)) {
-		test(`${util} is available on the public API`, () => {
-			expect(PUBLIC).toContain(util);
-		});
+	test("should export exactly the documented surface", () => {
+		expect(Object.keys(brazilianUtils).sort()).toEqual(PUBLIC);
+	});
+
+	test("should not list the same export twice", () => {
+		expect(PUBLIC.length).toBe(new Set(PUBLIC).size);
+	});
+
+	test("should export every documented public type", () => {
+		const publicTypes: Partial<{
+			AddBusinessDaysParams: AddBusinessDaysParams;
+			AddressInfo: AddressInfo;
+			AreaCodeInfo: AreaCodeInfo;
+			Bank: Bank;
+			BoletoInfo: BoletoInfo;
+			CapitalizeOptions: CapitalizeOptions;
+			Cbo: Cbo;
+			CepAddressInfo: CepAddressInfo;
+			CepProvider: CepProvider;
+			Certidao: Certidao;
+			CertidaoType: CertidaoType;
+			Cfop: Cfop;
+			Cnae: Cnae;
+			ConvertCurrencyToWordsOptions: ConvertCurrencyToWordsOptions;
+			ConvertDateToWordsOptions: ConvertDateToWordsOptions;
+			ConvertNumberToWordsOptions: ConvertNumberToWordsOptions;
+			DifferenceInBusinessDaysParams: DifferenceInBusinessDaysParams;
+			FormatBoletoOptions: FormatBoletoOptions;
+			FormatCaepfOptions: FormatCaepfOptions;
+			FormatCeiOptions: FormatCeiOptions;
+			FormatCepOptions: FormatCepOptions;
+			FormatCertidaoOptions: FormatCertidaoOptions;
+			FormatCnhOptions: FormatCnhOptions;
+			FormatCnoOptions: FormatCnoOptions;
+			FormatCnpjOptions: FormatCnpjOptions;
+			FormatCnsOptions: FormatCnsOptions;
+			FormatCpfOptions: FormatCpfOptions;
+			FormatCurrencyOptions: FormatCurrencyOptions;
+			FormatPhoneOptions: FormatPhoneOptions;
+			FormatPisOptions: FormatPisOptions;
+			FormatProcessoJuridicoOptions: FormatProcessoJuridicoOptions;
+			GenerateBoletoOptions: GenerateBoletoOptions;
+			GenerateLicensePlateFormat: GenerateLicensePlateFormat;
+			GeneratePhoneType: GeneratePhoneType;
+			GeneratePixPayloadParams: GeneratePixPayloadParams;
+			GenerateProcessoJuridicoOptions: GenerateProcessoJuridicoOptions;
+			GetAddressInfoByCepOptions: GetAddressInfoByCepOptions;
+			GetBoletoInfoOptions: GetBoletoInfoOptions;
+			GetCepInfoByAddressOptions: GetCepInfoByAddressOptions;
+			GetHolidaysOptions: GetHolidaysOptions;
+			GetMunicipalityByCodeOptions: GetMunicipalityByCodeOptions;
+			GetMunicipalityByNameOptions: GetMunicipalityByNameOptions;
+			GetMunicipalityOptions: GetMunicipalityOptions;
+			Holiday: Holiday;
+			HolidayType: HolidayType;
+			Iban: Iban;
+			IsBusinessDayOptions: IsBusinessDayOptions;
+			IsHolidayOptions: IsHolidayOptions;
+			IsValidBankAccountOptions: IsValidBankAccountOptions;
+			IsValidBankAccountParams: IsValidBankAccountParams;
+			IsValidCertidaoOptions: IsValidCertidaoOptions;
+			IsValidCnpjOptions: IsValidCnpjOptions;
+			IsValidCstOptions: IsValidCstOptions;
+			IsValidMobilePhoneOptions: IsValidMobilePhoneOptions;
+			IsValidPhoneOptions: IsValidPhoneOptions;
+			IsValidPixKeyOptions: IsValidPixKeyOptions;
+			IsValidRegistroProfissionalOptions: IsValidRegistroProfissionalOptions;
+			LegalNature: LegalNature;
+			LicensePlateFormat: LicensePlateFormat;
+			Municipality: Municipality;
+			NfeKey: NfeKey;
+			NumberToWordsGender: NumberToWordsGender;
+			ParseCnpjOptions: ParseCnpjOptions;
+			ParseCurrencyOptions: ParseCurrencyOptions;
+			PhoneMask: PhoneMask;
+			PhoneType: PhoneType;
+			PhoneVersion: PhoneVersion;
+			PixKey: PixKey;
+			PixKeyType: PixKeyType;
+			PixPayload: PixPayload;
+			PixPointOfInitiation: PixPointOfInitiation;
+			RegistroProfissionalCouncil: RegistroProfissionalCouncil;
+			State: State;
+			StateCode: StateCode;
+			StateName: StateName;
+			WordsCase: WordsCase;
+		}> = {};
+
+		expect(publicTypes).toEqual({});
+	});
+});
+
+describe("Public API contract: never throws on bad input", () => {
+	const entries = Object.entries(brazilianUtils).filter(
+		([name, value]) =>
+			typeof value === "function" && !isErrorClass(name) && !NETWORK_ENTRY_POINTS.has(name),
+	) as Array<[string, (...args: unknown[]) => unknown]>;
+
+	for (const [name, fn] of entries) {
+		for (const [label, value] of BAD_INPUTS) {
+			test(`${name} should not throw for ${label}`, async () => {
+				let thrown: unknown;
+
+				try {
+					const result = fn(value);
+
+					if (result instanceof Promise) await result;
+				} catch (error) {
+					thrown = error;
+				}
+
+				expect(thrown).toBeUndefined();
+			});
+
+			test(`${name} should not throw for ${label} as its second argument`, async () => {
+				let thrown: unknown;
+
+				try {
+					const result = fn("123", value);
+
+					if (result instanceof Promise) await result;
+				} catch (error) {
+					thrown = error;
+				}
+
+				expect(thrown).toBeUndefined();
+			});
+		}
 	}
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,36 +1,76 @@
+export type { Bank } from "./_internals/constants/banks";
+export type { Municipality } from "./_internals/constants/cities";
+export type { State, StateCode, StateName } from "./_internals/constants/states";
+export type { NumberToWordsGender, WordsCase } from "./_internals/number-to-words/number-to-words";
+export { type AddBusinessDaysParams, addBusinessDays } from "./add-business-days/add-business-days";
 export { type CapitalizeOptions, capitalize } from "./capitalize/capitalize";
+export {
+	type ConvertCurrencyToWordsOptions,
+	convertCurrencyToWords,
+} from "./convert-currency-to-words/convert-currency-to-words";
+export {
+	type ConvertDateToWordsOptions,
+	convertDateToWords,
+} from "./convert-date-to-words/convert-date-to-words";
+export { convertLicensePlateToMercosul } from "./convert-license-plate-to-mercosul/convert-license-plate-to-mercosul";
+export {
+	type ConvertNumberToWordsOptions,
+	convertNumberToWords,
+} from "./convert-number-to-words/convert-number-to-words";
+export {
+	type DifferenceInBusinessDaysParams,
+	differenceInBusinessDays,
+} from "./difference-in-business-days/difference-in-business-days";
 export { type FormatBoletoOptions, formatBoleto } from "./format-boleto/format-boleto";
+export { type FormatCaepfOptions, formatCaepf } from "./format-caepf/format-caepf";
+export { type FormatCeiOptions, formatCei } from "./format-cei/format-cei";
 export { type FormatCepOptions, formatCep } from "./format-cep/format-cep";
+export { type FormatCertidaoOptions, formatCertidao } from "./format-certidao/format-certidao";
+export { formatCnae } from "./format-cnae/format-cnae";
 export { type FormatCnhOptions, formatCnh } from "./format-cnh/format-cnh";
+export { type FormatCnoOptions, formatCno } from "./format-cno/format-cno";
 export { type FormatCnpjOptions, formatCnpj } from "./format-cnpj/format-cnpj";
+export { type FormatCnsOptions, formatCns } from "./format-cns/format-cns";
 export { type FormatCpfOptions, formatCpf } from "./format-cpf/format-cpf";
 export { type FormatCurrencyOptions, formatCurrency } from "./format-currency/format-currency";
+export { formatIban } from "./format-iban/format-iban";
 export { formatLegalNature } from "./format-legal-nature/format-legal-nature";
 export { formatLicensePlate } from "./format-license-plate/format-license-plate";
+export { formatNcm } from "./format-ncm/format-ncm";
+export { formatNfeKey } from "./format-nfe-key/format-nfe-key";
 export { formatPassport } from "./format-passport/format-passport";
-export { type FormatPhoneOptions, formatPhone } from "./format-phone/format-phone";
+export { type FormatPhoneOptions, type PhoneMask, formatPhone } from "./format-phone/format-phone";
 export { type FormatPisOptions, formatPis } from "./format-pis/format-pis";
 export {
 	type FormatProcessoJuridicoOptions,
 	formatProcessoJuridico,
 } from "./format-processo-juridico/format-processo-juridico";
 export { formatVoterId } from "./format-voter-id/format-voter-id";
-export { generateBoleto } from "./generate-boleto/generate-boleto";
+export { type GenerateBoletoOptions, generateBoleto } from "./generate-boleto/generate-boleto";
 export { generateCep } from "./generate-cep/generate-cep";
 export { generateCnh } from "./generate-cnh/generate-cnh";
 export { generateCnpj } from "./generate-cnpj/generate-cnpj";
 export { generateCpf } from "./generate-cpf/generate-cpf";
 export { generateLegalNature } from "./generate-legal-nature/generate-legal-nature";
-export { generateLicensePlate } from "./generate-license-plate/generate-license-plate";
+export {
+	type GenerateLicensePlateFormat,
+	generateLicensePlate,
+} from "./generate-license-plate/generate-license-plate";
 export { generatePassport } from "./generate-passport/generate-passport";
 export { generatePhone, type GeneratePhoneType } from "./generate-phone/generate-phone";
 export { generatePis } from "./generate-pis/generate-pis";
+export {
+	type GeneratePixPayloadParams,
+	generatePixPayload,
+} from "./generate-pix-payload/generate-pix-payload";
 export {
 	type GenerateProcessoJuridicoOptions,
 	generateProcessoJuridico,
 } from "./generate-processo-juridico/generate-processo-juridico";
 export { generateVoterId } from "./generate-voter-id/generate-voter-id";
 export {
+	type AddressInfo,
+	type CepProvider,
 	GetAddressInfoByCepError,
 	GetAddressInfoByCepNotFoundError,
 	type GetAddressInfoByCepOptions,
@@ -38,40 +78,80 @@ export {
 	GetAddressInfoByCepValidationError,
 	getAddressInfoByCep,
 } from "./get-address-info-by-cep/get-address-info-by-cep";
-export { getBoletoInfo } from "./get-boleto-info/get-boleto-info";
-export { getCities } from "./get-cities/get-cities";
+export { type AreaCodeInfo, getAreaCodeInfo } from "./get-area-code-info/get-area-code-info";
+export { getAreaCodesByState } from "./get-area-codes-by-state/get-area-codes-by-state";
+export { getBankByCode } from "./get-bank-by-code/get-bank-by-code";
+export { getBankByIspb } from "./get-bank-by-ispb/get-bank-by-ispb";
+export { getBanks } from "./get-banks/get-banks";
 export {
+	type BoletoInfo,
+	type GetBoletoInfoOptions,
+	getBoletoInfo,
+} from "./get-boleto-info/get-boleto-info";
+export { type Cbo, getCbo } from "./get-cbo/get-cbo";
+export {
+	type CepAddressInfo,
 	GetCepInfoByAddressError,
 	GetCepInfoByAddressNotFoundError,
-	type CepAddressInfo,
 	type GetCepInfoByAddressOptions,
 	GetCepInfoByAddressValidationError,
 	getCepInfoByAddress,
 } from "./get-cep-info-by-address/get-cep-info-by-address";
+export { type Cfop, getCfop } from "./get-cfop/get-cfop";
+export { getCities } from "./get-cities/get-cities";
+export { type Cnae, getCnae } from "./get-cnae/get-cnae";
 export {
 	getFormatLicensePlate,
 	type LicensePlateFormat,
 } from "./get-format-license-plate/get-format-license-plate";
-export { type GetHolidaysOptions, getHolidays } from "./get-holidays/get-holidays";
+export {
+	type GetHolidaysOptions,
+	type Holiday,
+	type HolidayType,
+	getHolidays,
+} from "./get-holidays/get-holidays";
+export { type LegalNature, getLegalNature } from "./get-legal-nature/get-legal-nature";
 export { getLegalNatures } from "./get-legal-natures/get-legal-natures";
+export { getMunicipalities } from "./get-municipalities/get-municipalities";
 export {
 	type GetMunicipalityByCodeOptions,
 	type GetMunicipalityByNameOptions,
 	type GetMunicipalityOptions,
 	getMunicipality,
 } from "./get-municipality/get-municipality";
+export { getMunicipalityByCode } from "./get-municipality-by-code/get-municipality-by-code";
+export { getStateByIbgeCode } from "./get-state-by-ibge-code/get-state-by-ibge-code";
+export { getStateCodeByName } from "./get-state-code-by-name/get-state-code-by-name";
+export { getStateNameByCode } from "./get-state-name-by-code/get-state-name-by-code";
 export { getStates } from "./get-states/get-states";
+export { getTimezoneByState } from "./get-timezone-by-state/get-timezone-by-state";
+export { type IsBusinessDayOptions, isBusinessDay } from "./is-business-day/is-business-day";
 export { type IsHolidayOptions, isHoliday } from "./is-holiday/is-holiday";
 export {
 	type IsValidBankAccountOptions,
 	isValidBankAccount,
 } from "./is-valid-bank-account/is-valid-bank-account";
 export { isValidBoleto } from "./is-valid-boleto/is-valid-boleto";
+export { isValidCaepf } from "./is-valid-caepf/is-valid-caepf";
+export { isValidCbo } from "./is-valid-cbo/is-valid-cbo";
+export { isValidCei } from "./is-valid-cei/is-valid-cei";
 export { isValidCep } from "./is-valid-cep/is-valid-cep";
+export {
+	type IsValidCertidaoOptions,
+	isValidCertidao,
+} from "./is-valid-certidao/is-valid-certidao";
+export { isValidCfop } from "./is-valid-cfop/is-valid-cfop";
+export { isValidCnae } from "./is-valid-cnae/is-valid-cnae";
 export { isValidCnh } from "./is-valid-cnh/is-valid-cnh";
-export { isValidCnpj } from "./is-valid-cnpj/is-valid-cnpj";
+export { isValidCno } from "./is-valid-cno/is-valid-cno";
+export { type IsValidCnpjOptions, isValidCnpj } from "./is-valid-cnpj/is-valid-cnpj";
+export { isValidCns } from "./is-valid-cns/is-valid-cns";
 export { isValidCpf } from "./is-valid-cpf/is-valid-cpf";
+export { isValidCreditCard } from "./is-valid-credit-card/is-valid-credit-card";
+export { isValidCsosn } from "./is-valid-csosn/is-valid-csosn";
+export { type IsValidCstOptions, isValidCst } from "./is-valid-cst/is-valid-cst";
 export { isValidEmail } from "./is-valid-email/is-valid-email";
+export { isValidIban } from "./is-valid-iban/is-valid-iban";
 export { isValidIe } from "./is-valid-ie/is-valid-ie";
 export { isValidLandlinePhone } from "./is-valid-landline-phone/is-valid-landline-phone";
 export { isValidLegalNature } from "./is-valid-legal-nature/is-valid-legal-nature";
@@ -80,74 +160,71 @@ export {
 	type IsValidMobilePhoneOptions,
 	isValidMobilePhone,
 } from "./is-valid-mobile-phone/is-valid-mobile-phone";
+export { isValidNcm } from "./is-valid-ncm/is-valid-ncm";
+export { isValidNfeKey } from "./is-valid-nfe-key/is-valid-nfe-key";
 export { isValidPassport } from "./is-valid-passport/is-valid-passport";
-export { type IsValidPhoneOptions, isValidPhone } from "./is-valid-phone/is-valid-phone";
+export {
+	type IsValidPhoneOptions,
+	type PhoneType,
+	type PhoneVersion,
+	isValidPhone,
+} from "./is-valid-phone/is-valid-phone";
 export { isValidPis } from "./is-valid-pis/is-valid-pis";
+export { type IsValidPixKeyOptions, isValidPixKey } from "./is-valid-pix-key/is-valid-pix-key";
+export { isValidPixPayload } from "./is-valid-pix-payload/is-valid-pix-payload";
 export { isValidProcessoJuridico } from "./is-valid-processo-juridico/is-valid-processo-juridico";
+export type { RegistroProfissionalCouncil } from "./is-valid-registro-profissional/constants";
+export {
+	type IsValidRegistroProfissionalOptions,
+	isValidRegistroProfissional,
+} from "./is-valid-registro-profissional/is-valid-registro-profissional";
 export { isValidRenavam } from "./is-valid-renavam/is-valid-renavam";
+export { isValidServicePhone } from "./is-valid-service-phone/is-valid-service-phone";
+export { isValidVin } from "./is-valid-vin/is-valid-vin";
 export { isValidVoterId } from "./is-valid-voter-id/is-valid-voter-id";
 export { parseBoleto } from "./parse-boleto/parse-boleto";
 export { parseCep } from "./parse-cep/parse-cep";
+export { type Certidao, type CertidaoType, parseCertidao } from "./parse-certidao/parse-certidao";
 export { parseCnh } from "./parse-cnh/parse-cnh";
-export { parseCnpj } from "./parse-cnpj/parse-cnpj";
+export { type ParseCnpjOptions, parseCnpj } from "./parse-cnpj/parse-cnpj";
 export { parseCpf } from "./parse-cpf/parse-cpf";
-export { parseCurrency } from "./parse-currency/parse-currency";
+export { type ParseCurrencyOptions, parseCurrency } from "./parse-currency/parse-currency";
+export { type Iban, parseIban } from "./parse-iban/parse-iban";
 export { parseLegalNature } from "./parse-legal-nature/parse-legal-nature";
 export { parseLicensePlate } from "./parse-license-plate/parse-license-plate";
+export { type NfeKey, parseNfeKey } from "./parse-nfe-key/parse-nfe-key";
 export { parsePassport } from "./parse-passport/parse-passport";
 export { parsePhone } from "./parse-phone/parse-phone";
 export { parsePis } from "./parse-pis/parse-pis";
+export { type PixKey, type PixKeyType, parsePixKey } from "./parse-pix-key/parse-pix-key";
+export {
+	type PixPayload,
+	type PixPointOfInitiation,
+	parsePixPayload,
+} from "./parse-pix-payload/parse-pix-payload";
 export { parseProcessoJuridico } from "./parse-processo-juridico/parse-processo-juridico";
 export { parseVoterId } from "./parse-voter-id/parse-voter-id";
+export { removeAccents } from "./remove-accents/remove-accents";
 
-// ============================================================================
-// DEPRECATED EXPORTS - Will be removed in v3.0.0
-// ============================================================================
-
-/**
- * @deprecated Use `IsValidBankAccountOptions` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `IsValidBankAccountOptions` instead. */
 export type { IsValidBankAccountParams } from "./is-valid-bank-account/is-valid-bank-account";
-
-/**
- * @deprecated Use `formatCep` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `formatCep` instead. */
 export { formatCep as formatCEP } from "./format-cep/format-cep";
-
-/**
- * @deprecated Use `formatCnpj` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `formatCnpj` instead. */
 export { formatCnpj as formatCNPJ } from "./format-cnpj/format-cnpj";
-
-/**
- * @deprecated Use `formatCpf` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `formatCpf` instead. */
 export { formatCpf as formatCPF } from "./format-cpf/format-cpf";
-/**
- * @deprecated Use `generateCnpj` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `generateCnpj` instead. */
 export { generateCnpj as generateCNPJ } from "./generate-cnpj/generate-cnpj";
-/**
- * @deprecated Use `generateCpf` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `generateCpf` instead. */
 export { generateCpf as generateCPF } from "./generate-cpf/generate-cpf";
-/**
- * @deprecated Use `isValidCep` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `isValidCep` instead. */
 export { isValidCep as isValidCEP } from "./is-valid-cep/is-valid-cep";
-/**
- * @deprecated Use `isValidCnpj` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `isValidCnpj` instead. */
 export { isValidCnpj as isValidCNPJ } from "./is-valid-cnpj/is-valid-cnpj";
-/**
- * @deprecated Use `isValidCpf` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `isValidCpf` instead. */
 export { isValidCpf as isValidCPF } from "./is-valid-cpf/is-valid-cpf";
-/**
- * @deprecated Use `isValidIe` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `isValidIe` instead. */
 export { isValidIe as isValidIE } from "./is-valid-ie/is-valid-ie";
-/**
- * @deprecated Use `isValidPis` instead. This alias will be removed in v3.0.0
- */
+/** @deprecated Use `isValidPis` instead. */
 export { isValidPis as isValidPIS } from "./is-valid-pis/is-valid-pis";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -141,6 +141,10 @@ export default defineConfig({
 		useTabs: true,
 	},
 	lint: {
+		options: {
+			typeAware: true,
+			typeCheck: true,
+		},
 		categories: {
 			correctness: "error",
 			suspicious: "error",
@@ -197,6 +201,12 @@ export default defineConfig({
 				"src/_internals/constants/**",
 				"src/index.ts",
 			],
+			thresholds: {
+				statements: 100,
+				branches: 100,
+				functions: 100,
+				lines: 100,
+			},
 		},
 	},
 	pack: [


### PR DESCRIPTION
## What does this PR do?

Part 7 of 18 of the 2.4.0 release stack (main <- stack/01-tooling <- ... <- stack/11-testing). The package-root exports (`src/index.ts`, 124 exports plus 10 deprecated aliases kept for compatibility), the public type re-exports and the Bun/Deno test runtime shim refresh. Closes with the commit that turns on type-aware lint with type checking and the 100% coverage thresholds, now that the whole tree meets them.

## Commits in this part (2)

- 6c67309 feat: export public types from the package root
- 17a50c9 ci(test): enforce 100% coverage and type-aware lint

## How to review and merge

- Review each part on its own; the diff of this PR is exactly the commits above.
- Every part is green on its own: each branch builds, lints, passes the tests on Node 20/22/24/26, Bun, Deno and the four browsers, and passes the tree-shaking check against the part below it.
- Do not merge the lower parts individually. When all eighteen are approved, retarget #520 to `main` and merge it with a merge commit: the reviewed commits land unchanged and GitHub marks the seventeen parts below as merged.
- Zero breaking changes: every existing signature, export, entry point and error message is preserved. Twelve output corrections were validated against the published 2.3.0 tarball and are listed in `CHANGELOG.md` (part 7); the build of every later part is compared export by export against the part below it.

## Stack

- Previous: #511
- Next: #513
- Top of stack: #520
